### PR TITLE
feat: allow to search students by email, name and username

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,17 @@ Unreleased
 
 *
 
+0.2.0 - 2023-11-23
+
+Added
+=====
+
+* Search students by username, email or name.
+
 0.1.0 – 2023-11-23
 **********************************************
 
 Added
 =====
 
-* First release on PyPI.
+* Clone send email functionality with extra targets.

--- a/platform_plugin_communications/__init__.py
+++ b/platform_plugin_communications/__init__.py
@@ -2,4 +2,4 @@
 An Open edX plugin that extends email capabilities.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/platform_plugin_communications/api/serializers.py
+++ b/platform_plugin_communications/api/serializers.py
@@ -1,0 +1,16 @@
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+User = get_user_model()
+
+
+class UserSearchSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="profile.name", read_only=True)
+
+    class Meta:
+        model = User
+        fields = (
+            "username",
+            "email",
+            "name",
+        )

--- a/platform_plugin_communications/api/serializers.py
+++ b/platform_plugin_communications/api/serializers.py
@@ -1,3 +1,6 @@
+"""
+Serializers for the platform_plugin_communications app.
+"""
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
@@ -5,6 +8,10 @@ User = get_user_model()
 
 
 class UserSearchSerializer(serializers.ModelSerializer):
+    """
+    Serializer for User model.
+    """
+
     name = serializers.CharField(source="profile.name", read_only=True)
 
     class Meta:

--- a/platform_plugin_communications/api/views.py
+++ b/platform_plugin_communications/api/views.py
@@ -146,7 +146,7 @@ def search_learner(request, course_id):
     course_id = CourseKey.from_string(course_id)
     query = request.GET.get("query", "")
 
-    base_queryset = User.objects.filter(
+    queryset = User.objects.filter(
         is_active=True,
         courseenrollment__course_id=course_id,
         courseenrollment__is_active=True,
@@ -157,7 +157,7 @@ def search_learner(request, course_id):
         if data:
             queryset = data
         else:
-            queryset = base_queryset.filter(
+            queryset = queryset.filter(
                 models.Q(  # pylint: disable=unsupported-binary-operation
                     email__icontains=query
                 )
@@ -165,8 +165,6 @@ def search_learner(request, course_id):
                 | models.Q(profile__name__icontains=query),
             ).distinct()
             cache.set(cache_key, queryset, 60)
-    else:
-        queryset = base_queryset
 
     page_number = request.GET.get("page", 1)
     page_size = request.GET.get("page_size", 50)

--- a/platform_plugin_communications/api/views.py
+++ b/platform_plugin_communications/api/views.py
@@ -5,14 +5,17 @@ import logging
 
 import dateutil
 import pytz
-from django.db import transaction
+from django.contrib.auth import get_user_model
+from django.core.paginator import Paginator
+from django.db import models, transaction
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_GET, require_POST
 from opaque_keys.edx.keys import CourseKey
 
 import platform_plugin_communications.utils as task_api
+from platform_plugin_communications.api.serializers import UserSearchSerializer
 from platform_plugin_communications.edxapp_wrapper.bulk_email import create_course_email, is_bulk_email_feature_enabled
 from platform_plugin_communications.edxapp_wrapper.course_overviews import get_course_overview_or_none
 from platform_plugin_communications.edxapp_wrapper.instructor_views import (
@@ -23,6 +26,8 @@ from platform_plugin_communications.edxapp_wrapper.instructor_views import (
     require_course_permission,
     require_post_params,
 )
+
+User = get_user_model()
 
 log = logging.getLogger(__name__)
 
@@ -43,6 +48,16 @@ def send_email_api_view(request, course_id):
     Extracted from: lms.djangoapps.instructor.views.api import send_email
     """
     return send_email(request, course_id)
+
+
+@transaction.non_atomic_requests
+@require_GET
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_course_permission(permissions.EMAIL)
+@common_exceptions_400
+def search_learner_api_view(request, course_id):
+    return search_learner(request, course_id)
 
 
 def send_email(request, course_id):
@@ -117,5 +132,43 @@ def send_email(request, course_id):
         {
             "course_id": str(course_id),
             "success": True,
+        }
+    )
+
+
+def search_learner(request, course_id):
+    """
+    Search for learners based on the query param.
+    """
+    course_id = CourseKey.from_string(course_id)
+    query = request.GET.get("query", "")
+    base_queryset = User.objects.filter(
+        is_active=True,
+        courseenrollment__course_id=course_id,
+        courseenrollment__is_active=True,
+    )
+    if query:
+        queryset = base_queryset.filter(
+            models.Q(email__icontains=query)
+            | models.Q(username__icontains=query)
+            | models.Q(profile__name__icontains=query),
+        ).distinct()
+    else:
+        queryset = base_queryset
+
+    page_number = request.GET.get("page", 1)
+    page_size = request.GET.get("page_size", 50)
+    paginator = Paginator(queryset, page_size)
+    result_page = paginator.get_page(page_number)
+    data = UserSearchSerializer(result_page, many=True).data
+
+    return JsonResponse(
+        {
+            "course_id": str(course_id),
+            "page": page_number,
+            "page_count": paginator.num_pages,
+            "page_size": paginator.per_page,
+            "count": paginator.count,
+            "results": data,
         }
     )

--- a/platform_plugin_communications/api/views.py
+++ b/platform_plugin_communications/api/views.py
@@ -57,6 +57,9 @@ def send_email_api_view(request, course_id):
 @require_course_permission(permissions.EMAIL)
 @common_exceptions_400
 def search_learner_api_view(request, course_id):
+    """
+    Search for learners api view.
+    """
     return search_learner(request, course_id)
 
 
@@ -149,7 +152,9 @@ def search_learner(request, course_id):
     )
     if query:
         queryset = base_queryset.filter(
-            models.Q(email__icontains=query)
+            models.Q(  # pylint: disable=unsupported-binary-operation
+                email__icontains=query
+            )
             | models.Q(username__icontains=query)
             | models.Q(profile__name__icontains=query),
         ).distinct()
@@ -166,9 +171,9 @@ def search_learner(request, course_id):
         {
             "course_id": str(course_id),
             "page": page_number,
-            "page_count": paginator.num_pages,
+            "pages": paginator.num_pages,
             "page_size": paginator.per_page,
-            "count": paginator.count,
+            "total": paginator.count,
             "results": data,
         }
     )

--- a/platform_plugin_communications/tests/test_urls.py
+++ b/platform_plugin_communications/tests/test_urls.py
@@ -3,7 +3,7 @@ Test module for URLs.
 """
 from django.test import TestCase
 
-from platform_plugin_communications.api.views import send_email_api_view
+from platform_plugin_communications.api.views import search_learner_api_view, send_email_api_view
 from platform_plugin_communications.urls import urlpatterns
 
 
@@ -20,4 +20,8 @@ class UrlTestCases(TestCase):
         assert urlpatterns[0].name == "send_email"
         assert (  # pylint: disable=comparison-with-callable
             urlpatterns[0].callback == send_email_api_view
+        )
+        assert urlpatterns[1].name == "search_learners"
+        assert (  # pylint: disable=comparison-with-callable
+            urlpatterns[1].callback == search_learner_api_view
         )

--- a/platform_plugin_communications/tests/test_urls.py
+++ b/platform_plugin_communications/tests/test_urls.py
@@ -16,7 +16,7 @@ class UrlTestCases(TestCase):
         """
         Test case for checking the number of URL patterns.
         """
-        assert len(urlpatterns) == 1
+        assert len(urlpatterns) == 2
         assert urlpatterns[0].name == "send_email"
         assert (  # pylint: disable=comparison-with-callable
             urlpatterns[0].callback == send_email_api_view

--- a/platform_plugin_communications/tests/test_views.py
+++ b/platform_plugin_communications/tests/test_views.py
@@ -7,10 +7,11 @@ import json
 from unittest.mock import Mock, patch
 
 import pytz
+from django.db import models
 from django.test import TestCase, override_settings
 from opaque_keys.edx.keys import CourseKey
 
-from platform_plugin_communications.api.views import send_email
+from platform_plugin_communications.api.views import search_learner, send_email
 from platform_plugin_communications.edxapp_wrapper.instructor_tasks import InstructorTaskTypes
 from platform_plugin_communications.tasks import send_bulk_course_email
 
@@ -203,4 +204,110 @@ class TestSendEmailAPIView(TestCase):
         assert json.loads(response.content) == {
             "course_id": course_id,
             "success": True,
+        }
+
+
+class TestSearchUsersAPIView(TestCase):
+    """
+    Test case for search_learners_api_view.
+    """
+
+    @patch("platform_plugin_communications.api.views.User")
+    def test_search_users(self, mock_User):
+        """
+        Test case for search users API View.
+        """
+
+        request = Mock()
+        request.method = "GET"
+        request.GET = {}
+        course_id = "course-v1:edX+DemoX+Demo_Course"
+        course_key = CourseKey.from_string(course_id)
+        users = [
+            {
+                "email": "test@openedx.org",
+                "username": "test",
+                "name": "test",
+            }
+        ]
+        users_mock = []
+        for user in users:
+            user_mock = Mock()
+            user_mock.username = user["username"]
+            user_mock.email = user["email"]
+            user_mock.profile.name = user["name"]
+            users_mock.append(user_mock)
+        mock_User.objects.filter.return_value = users_mock
+        response = search_learner(request, course_id)
+
+        mock_User.objects.filter.assert_called_once_with(
+            is_active=True,
+            courseenrollment__course_id=course_key,
+            courseenrollment__is_active=True,
+        )
+        assert response.status_code == 200
+        assert json.loads(response.content) == {
+            "total": 1,
+            "page": 1,
+            "pages": 1,
+            "page_size": 50,
+            "course_id": course_id,
+            "results": users,
+        }
+
+    @patch("platform_plugin_communications.api.views.User")
+    def test_search_users_with_query(self, mock_User):
+        """
+        Test case for search users API View with query.
+        """
+
+        request = Mock()
+        request.method = "GET"
+        request.GET = {
+            "query": "test",
+        }
+        course_id = "course-v1:edX+DemoX+Demo_Course"
+        course_key = CourseKey.from_string(course_id)
+        users = [
+            {
+                "email": "test@openedx.org",
+                "username": "test",
+                "name": "test",
+            }
+        ]
+        users_mock = []
+        for user in users:
+            user_mock = Mock()
+            user_mock.username = user["username"]
+            user_mock.email = user["email"]
+            user_mock.profile.name = user["name"]
+            users_mock.append(user_mock)
+        mock_filter = Mock()
+        mock_User.objects.filter.return_value = mock_filter
+        mock_filter2 = Mock()
+        mock_filter.filter.return_value = mock_filter2
+        mock_filter2.distinct.return_value = users_mock
+        response = search_learner(request, course_id)
+
+        mock_User.objects.filter.assert_called_once_with(
+            is_active=True,
+            courseenrollment__course_id=course_key,
+            courseenrollment__is_active=True,
+        )
+        mock_User.objects.filter().filter.assert_called_once_with(
+            models.Q(  # pylint: disable=unsupported-binary-operation
+                email__icontains="test"
+            )
+            | models.Q(username__icontains="test")
+            | models.Q(profile__name__icontains="test"),
+        )
+        mock_User.objects.filter().filter().distinct.assert_called_once()
+        assert response.status_code == 200
+        assert json.loads(response.content) == {
+            "total": 1,
+            "page": 1,
+            "pages": 1,
+            "page_size": 50,
+            "course_id": course_id,
+            "results": users,
         }

--- a/platform_plugin_communications/urls.py
+++ b/platform_plugin_communications/urls.py
@@ -3,12 +3,17 @@ URLs for platform_plugin_communications.
 """
 from django.urls import path
 
-from platform_plugin_communications.api.views import send_email_api_view
+from platform_plugin_communications.api.views import search_learner_api_view, send_email_api_view
 
 urlpatterns = [
     path(
         "send_email",
         send_email_api_view,
         name="send_email",
+    ),
+    path(
+        "search_learners",
+        search_learner_api_view,
+        name="search_learners",
     ),
 ]


### PR DESCRIPTION
### Description

This PR adds a new endpoint to search students by username, email or name.

### Testing instructions

1. Open the following endpoint in your browser:
  `http://local.overhang.io:8000/platform-plugin-communications/{course-id}/api/search_learners?query=edu&page=1&page_size=10`
2. Modify the query parameters and verify the API response matches them.
3. The response should look like the following:

```json
{
  "course_id": "course-v1:demo+demo+demo",
  "page": 1,
  "page_count": 1,
  "page_size": 50,
  "count": 2,
  "results": [
    {
      "username": "admin",
      "email": "admin@edunext.co",
      "name": "admin"
    },
    {
      "username": "student",
      "email": "student@edunext.co",
      "name": "student"
    }
  ]
}
```